### PR TITLE
echo, cd, pwd 함수 구현 및 lexer의 quote 처리 함수를 cmd 처리 함수에 포함

### DIFF
--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -6,7 +6,47 @@
 /*   By: yehan <yehan@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/15 23:15:55 by minkyeki          #+#    #+#             */
-/*   Updated: 2022/07/18 16:52:12 by yehan            ###   ########seoul.kr  */
+/*   Updated: 2022/07/19 14:44:25 by yehan            ###   ########seoul.kr  */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include "../libft/include/libft.h"
+#include <unistd.h>//chdir()
+#include <stdlib.h>//free()
+#include <stdio.h>//perror()
+
+/*
+** cd with only a relative or absolute path.
+** NOTE: chdir() work with both type.
+*/
+
+void	exec_cd(char **arglist)
+{
+	char	*message;
+
+	if (chdir(arglist[1]) == -1)
+	{
+		message = ft_strjoin("lesh: cd: ", arglist[1]);
+		perror(message);
+		free(message);
+	}
+}
+
+// main() for test
+//gcc cd.c ../libft/src/ft_strjoin.c ../libft/src/ft_strlen.c
+
+int	main()
+{
+	char **arglist = calloc(8, sizeof(char *));
+	arglist[0] = "cd";
+	arglist[1] = "/Users/yehan/minishell/src";
+	// arglist[1] = "..";
+	// arglist[1] = "/";
+	// arglist[1] = "/Users/yehan/mini";
+
+	exec_cd(arglist);
+
+	char *buf = calloc(1, 100);
+	getcwd(buf, 100);
+	printf("%s\n", buf);
+}

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -1,0 +1,43 @@
+#include "../parser/parse_tree.h"
+
+/*
+** example: [echo] [-nnn] [a] [b] [-n] [c]
+** 1) check 2th node
+** 1-1) if NULL -> do nothing
+** 1-2) if -n && only n detected -> -n option on
+** 2) print from 3th to last
+*/
+
+int	is_n_option(char *text)
+{
+	else if (ft_strncmp(cur->content->str->text, "-n", 2))
+	while ()
+}
+
+void	builtin_echo(t_list *token_list)
+{
+	t_list	*cur;
+	int		n_option;
+
+	cur = token_list;
+	cur = cur->next;
+	if (cur == NULL)
+		return ;
+	n_option = FALSE;
+	if (is_n_option(cur->next->content->str->text) == TRUE)
+		n_option = TRUE;
+
+}
+
+void	set_redirection(t_list *redir_list)
+{
+	t_list	*cur;
+
+	close(/*원래 in*/);
+	close(/*원래 out*/);
+	cur = redir_list;
+	while (cur)
+	{
+		//
+	}
+}

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -1,8 +1,11 @@
-#include "../lexer/scanner.h"
-#include "../parser/parse_tree.h"
+# include <stdlib.h>
+# include <unistd.h> //STDOUT, IN
+# include "../libft/include/libft.h"
 
-# define TRUE 1;
-# define FALSE 0;
+# define TRUE 1
+# define FALSE 0
+
+// # define FILENO_STDOUT 0
 
 /*
 ** example: [echo] [-nnn] [a] [b] [-n] [c]
@@ -16,26 +19,24 @@ static int	is_n_option(char *str)
 {
 	size_t	i;
 
-	i = 0;
-	if (ft_strncmp(str, "-n", 2))
+	if (!ft_strncmp(str, "-n", 2))
 	{
-		i = i + 2;
+		i = 2;
 		while (str[i] == 'n')
 			i++;
 		if (str[i] == '\0')
 				return (TRUE);
 	}
-	else
-		return (FALSE);
+	return (FALSE);
 }
 
 static void	write_arguments(char **arglist, size_t i)
 {
 	while (arglist[i])
 	{
-		ft_putstr_fd(cur->content->string->str, FILENO_STDOUT);
+		ft_putstr_fd(arglist[i], STDOUT_FILENO);
 		if (arglist[i + 1])
-			ft_putchar_fd(' ', FILENO_STDOUT);
+			ft_putchar_fd(' ', STDOUT_FILENO);
 		i++;
 	}
 }
@@ -52,5 +53,17 @@ void	exec_echo(char **arglist)
 		write_arguments(arglist, 1 + n_option);
 	}
 	if (n_option == FALSE)
-		ft_putchar_fd('\n', FILENO_STDOUT);
+		ft_putchar_fd('\n', STDOUT_FILENO);
+}
+
+//gcc -g echo.c ../libft/src/ft_putstr_fd.c ../libft/src/ft_putchar_fd.c ../libft/src/ft_strncmp.c ../libft/src/ft_strlen.c
+int main()
+{
+	char **arglist = calloc(8, sizeof(char *));
+	arglist[0] = "echo";
+	arglist[1] = "-nnn";
+	arglist[2] = "a  dd";
+	arglist[3] = "b";
+
+	exec_echo(arglist);
 }

--- a/src/builtin/echo.c
+++ b/src/builtin/echo.c
@@ -1,4 +1,8 @@
+#include "../lexer/scanner.h"
 #include "../parser/parse_tree.h"
+
+# define TRUE 1;
+# define FALSE 0;
 
 /*
 ** example: [echo] [-nnn] [a] [b] [-n] [c]
@@ -8,36 +12,45 @@
 ** 2) print from 3th to last
 */
 
-int	is_n_option(char *text)
+static int	is_n_option(char *str)
 {
-	else if (ft_strncmp(cur->content->str->text, "-n", 2))
-	while ()
+	size_t	i;
+
+	i = 0;
+	if (ft_strncmp(str, "-n", 2))
+	{
+		i = i + 2;
+		while (str[i] == 'n')
+			i++;
+		if (str[i] == '\0')
+				return (TRUE);
+	}
+	else
+		return (FALSE);
 }
 
-void	builtin_echo(t_list *token_list)
+static void	write_arguments(char **arglist, size_t i)
 {
-	t_list	*cur;
+	while (arglist[i])
+	{
+		ft_putstr_fd(cur->content->string->str, FILENO_STDOUT);
+		if (arglist[i + 1])
+			ft_putchar_fd(' ', FILENO_STDOUT);
+		i++;
+	}
+}
+
+void	exec_echo(char **arglist)
+{
 	int		n_option;
 
-	cur = token_list;
-	cur = cur->next;
-	if (cur == NULL)
-		return ;
 	n_option = FALSE;
-	if (is_n_option(cur->next->content->str->text) == TRUE)
-		n_option = TRUE;
-
-}
-
-void	set_redirection(t_list *redir_list)
-{
-	t_list	*cur;
-
-	close(/*원래 in*/);
-	close(/*원래 out*/);
-	cur = redir_list;
-	while (cur)
+	if (arglist[1] != NULL)
 	{
-		//
+		if (is_n_option(arglist[1]) == TRUE)
+			n_option = TRUE;
+		write_arguments(arglist, 1 + n_option);
 	}
+	if (n_option == FALSE)
+		ft_putchar_fd('\n', FILENO_STDOUT);
 }

--- a/src/builtin/pwd.c
+++ b/src/builtin/pwd.c
@@ -1,18 +1,32 @@
-# include <unistd.h> //getcwd()
-# include <sys/param.h> // define MAXPATHLEN 1024 (man getwd)
-# include "../libft/include.libft.h"
+# include <unistd.h>//getcwd(), STDOUT
+# include <stdio.h>//perror()
+# include <sys/param.h>//define MAXPATHLEN 1024 (man getwd)
+# include "../libft/include/libft.h"
 
 /*
 ** NOTE1: It is independent of environment variable PWD.
 ** NOTE2: All arguments are ignored.
 */
 
-void	exec_pwd(char **arglist)
+void	exec_pwd(char **arglist/* 인자는 사용되지 않는다. */)
 {
 	char	*buf;
 
 	buf = ft_calloc(1, MAXPATHLEN);
-	getcwd(buf, sizeof(*buf));
-	ft_putstr_fd(buf, FILENO_STDOUT);
+	if (getcwd(buf, MAXPATHLEN) == NULL)
+		perror("lesh: pwd");
+	ft_putstr_fd(buf, STDOUT_FILENO);
 	free(buf);
+}
+
+//gcc -g pwd.c ../libft/src/ft_calloc.c ../libft/src/ft_putstr_fd.c ../libft/src/ft_bzero.c ../libft/src/ft_strlen.c
+int main()
+{
+	char **arglist = calloc(8, sizeof(char *));
+	arglist[0] = "pwd";
+	arglist[1] = "a";
+	arglist[2] = "c";
+	arglist[3] = "b";
+
+	exec_pwd(arglist);
 }

--- a/src/builtin/pwd.c
+++ b/src/builtin/pwd.c
@@ -1,0 +1,18 @@
+# include <unistd.h> //getcwd()
+# include <sys/param.h> // define MAXPATHLEN 1024 (man getwd)
+# include "../libft/include.libft.h"
+
+/*
+** NOTE1: It is independent of environment variable PWD.
+** NOTE2: All arguments are ignored.
+*/
+
+void	exec_pwd(char **arglist)
+{
+	char	*buf;
+
+	buf = ft_calloc(1, MAXPATHLEN);
+	getcwd(buf, sizeof(*buf));
+	ft_putstr_fd(buf, FILENO_STDOUT);
+	free(buf);
+}


### PR DESCRIPTION
## echo, cd, pwd 구현
- test용 main()을 넣어두었습니다.
- 노션>구현리스트>details 그리고 주석을 참고해주세요.

## quote 처리방식 변경 
### test case
- echo 'ab'ARGc"k"d'e  |'     ab d 'c' 
- "ls"도 처리됩니다.

### 동작
- 인자 별로 토큰화되고
- 쿼트는 제거됩니다.

단, $가 이미 확장된 상태의 line이 들어온다는 가정이 필요합니다.

우리의 첫 풀 리퀘스트,,,!! >.<
